### PR TITLE
tw_penalty: add intra-route lower bound estimator

### DIFF
--- a/src/modification.c
+++ b/src/modification.c
@@ -75,13 +75,15 @@ modification_apply(struct modification m)
 		break;
 	}
 	case OUT_RELOCATE: {
+		if (m.v == m.w)
+			return;
 		rlist_move_entry(
 			rlist_prev(&m.v->in_route), m.w, in_route);
 		m.w->route = v_route;
 		break;
 	}
 	case EXCHANGE: {
-		if (m.v->id == 0 && m.w->id == 0)
+		if (m.v == m.w)
 			return;
 		rlist_swap_items(&m.v->in_route, &m.w->in_route);
 		SWAP(m.v->route, m.w->route);

--- a/src/rlist_extra.h
+++ b/src/rlist_extra.h
@@ -9,10 +9,21 @@ rlist_swap_items(struct rlist *lhs, struct rlist *rhs)
 {
 	assert(lhs->next != lhs);
 	assert(rhs->next != rhs);
-	SWAP(lhs->prev, rhs->prev);
-	SWAP(lhs->next, rhs->next);
-	SWAP(lhs->prev->next, rhs->prev->next);
-	SWAP(lhs->next->prev, rhs->next->prev);
+	if (rhs->next == lhs)
+		SWAP(lhs, rhs);
+	if (lhs->next == rhs) {
+		SWAP(lhs->prev, rhs->prev);
+		SWAP(lhs->next, rhs->next);
+		lhs->next->prev = lhs;
+		rhs->prev->next = rhs;
+		lhs->prev = rhs;
+		rhs->next = lhs;
+	} else {
+		SWAP(lhs->prev, rhs->prev);
+		SWAP(lhs->next, rhs->next);
+		SWAP(lhs->prev->next, rhs->prev->next);
+		SWAP(lhs->next->prev, rhs->next->prev);
+	}
 }
 
 void ALWAYS_INLINE

--- a/src/route.c
+++ b/src/route.c
@@ -28,6 +28,14 @@ route_init(struct route *r, struct customer **arr, int n)
 	route_check(r);
 }
 
+void
+route_init_penalty(struct route *r)
+{
+	c_penalty_init(r);
+        tw_penalty_init(r);
+        distance_init(r);
+}
+
 struct route *
 route_dup(struct route *r)
 {

--- a/src/route.h
+++ b/src/route.h
@@ -20,21 +20,25 @@ struct route {
 	assert(rlist_first_entry(&r->list, struct customer, in_route)->id == 0); \
 	assert(rlist_last_entry(&r->list, struct customer, in_route)->id == 0)
 
-#define route_init_penalty(r)	\
-	c_penalty_init(r);	\
-	tw_penalty_init(r);	\
-	distance_init(r)
-
 #define route_foreach(c, r) rlist_foreach_entry(c, &r->list, in_route)
+#define route_foreach_from(c, from, r)  \
+	for (c = from; !rlist_entry_is_head(c, &r->list, in_route); \
+	c = rlist_next_entry(c, in_route))
 
 #define depot_head(r) rlist_first_entry(&r->list, struct customer, in_route)
 #define depot_tail(r) rlist_last_entry(&r->list, struct customer, in_route)
+
+#define route_prev(c) rlist_prev_entry(c, in_route)
+#define route_next(c) rlist_next_entry(c, in_route)
 
 struct route *
 route_new();
 
 void
 route_init(struct route *r, struct customer **arr, int n);
+
+void
+route_init_penalty(struct route *r);
 
 struct route *
 route_dup(struct route *r);

--- a/src/tw_penalty.h
+++ b/src/tw_penalty.h
@@ -4,6 +4,7 @@
 #include "small/rlist.h"
 
 #define tw_penalty_attr \
+    int idx;            \
     double a;		\
     double tw_pf;	\
     double z;		\
@@ -11,6 +12,8 @@
 
 #include "customer.h"
 #include "route.h"
+
+#include <stdbool.h>
 
 void
 tw_penalty_init(struct route *r);
@@ -69,5 +72,9 @@ tw_penalty_exchange_penalty_delta_fast(struct customer *v, struct customer *w);
 double
 tw_penalty_exchange_penalty_delta(struct customer *v, struct customer *w);
 
+double
+tw_penalty_exchange_penalty_delta_lower_bound(struct customer *v,
+					      struct customer *w,
+					      bool *exact);
 
 #endif //EAMA_ROUTES_MINIMIZATION_HEURISTIC_TW_PENALTY_H

--- a/src/utils.h
+++ b/src/utils.h
@@ -50,6 +50,16 @@ extern "C" {
 # define MIN(a, b) ((a) < (b) ? (a) : (b))
 #endif
 
+#define EPS1 1e-1
+#define EPS2 1e-2
+#define EPS3 1e-3
+#define EPS4 1e-4
+#define EPS5 1e-5
+#define EPS6 1e-6
+#define EPS7 1e-7
+#define EPS8 1e-8
+#define EPS9 1e-9
+
 #define SWAP(a, b) do {							\
 	__typeof__(a) tmp = (a);					\
 	(a) = (b);							\

--- a/test/unit/c_penalty.c
+++ b/test/unit/c_penalty.c
@@ -19,6 +19,7 @@ static const struct penalty_vtab c_penalty_vtab = {
 	/* .penalty_two_opt_penalty_delta = */ c_penalty_two_opt_penalty_delta,
 	/* .penalty_out_relocate_penalty_delta = */c_penalty_out_relocate_penalty_delta,
 	/* .penalty_exchange_penalty_delta = */c_penalty_exchange_penalty_delta,
+	/* .tw_penalty_exchange_penalty_delta_lower_bound = */NULL,
 };
 
 int
@@ -31,6 +32,6 @@ main(void)
 	random_replacements(100);
 	random_two_opts(100);
 	random_out_relocations(100);
-	random_exchanges(100);
+	random_inter_route_exchanges(100);
 	return 0;
 }

--- a/test/unit/distance.c
+++ b/test/unit/distance.c
@@ -18,6 +18,7 @@ static const struct penalty_vtab distance_vtab = {
 	/* .penalty_two_opt_penalty_delta = */ distance_two_opt_distance_delta,
 	/* .penalty_out_relocate_penalty_delta = */distance_out_relocate_distance_delta,
 	/* .penalty_exchange_penalty_delta = */distance_exchange_distance_delta,
+	/* .tw_penalty_exchange_penalty_delta_lower_bound = */NULL,
 };
 
 int
@@ -30,6 +31,6 @@ main(void)
 	random_replacements(100);
 	random_two_opts(100);
 	random_out_relocations(100);
-	random_exchanges(100);
+	random_inter_route_exchanges(100);
 	return 0;
 }

--- a/test/unit/modification.c
+++ b/test/unit/modification.c
@@ -4,8 +4,8 @@
 
 #include "problem.h"
 
-#define assert_eq(lhs, rhs) if(lhs!=rhs)exit(1)
-#define assert_neq(lhs, rhs) if(lhs==rhs)exit(1)
+#define assert_eq(lhs, rhs) do{if(lhs!=rhs)exit(1);}while(0)
+#define assert_neq(lhs, rhs) do{if(lhs==rhs)exit(1);}while(0)
 
 #define RANDOM_MODIFICATIONS_BEFORE_INSERT
 #define RANDOM_MODIFICATIONS_AFTER_INSERT			\
@@ -92,8 +92,8 @@
 	}							\
 	assert_eq(k, p.n_customers + 1)
 
-#define RANDOM_MODIFICATIONS_BEFORE_EXCHANGE
-#define RANDOM_MODIFICATIONS_AFTER_EXCHANGE			\
+#define RANDOM_MODIFICATIONS_BEFORE_INTER_ROUTE_EXCHANGE
+#define RANDOM_MODIFICATIONS_AFTER_INTER_ROUTE_EXCHANGE		\
 	int k = 0;						\
 	route_foreach(v, v_route) {				\
 		if (v->id == 0)					\
@@ -110,6 +110,8 @@
 	}							\
 	assert_eq(k, p.n_customers)
 
+#define RANDOM_MODIFICATIONS_BEFORE_INTRA_ROUTE_EXCHANGE
+#define RANDOM_MODIFICATIONS_AFTER_INTRA_ROUTE_EXCHANGE
 
 #include "random_modifications.h"
 
@@ -123,8 +125,10 @@
 #undef RANDOM_MODIFICATIONS_AFTER_TWO_OPT
 #undef RANDOM_MODIFICATIONS_BEFORE_OUT_RELOCATE
 #undef RANDOM_MODIFICATIONS_AFTER_OUT_RELOCATE
-#undef RANDOM_MODIFICATIONS_BEFORE_EXCHANGE
-#undef RANDOM_MODIFICATIONS_AFTER_EXCHANGE
+#undef RANDOM_MODIFICATIONS_BEFORE_INTER_ROUTE_EXCHANGE
+#undef RANDOM_MODIFICATIONS_AFTER_INTER_ROUTE_EXCHANGE
+#undef RANDOM_MODIFICATIONS_BEFORE_INTRA_ROUTE_EXCHANGE
+#undef RANDOM_MODIFICATIONS_AFTER_INTRA_ROUTE_EXCHANGE
 
 int
 applicable()
@@ -244,7 +248,7 @@ main(void)
 	random_replacements(100);
 	random_two_opts(100);
 	random_out_relocations(100);
-	random_exchanges(100);
+	random_inter_route_exchanges(100);
 
 	applicable();
 	return 0;

--- a/test/unit/random_modifications.h
+++ b/test/unit/random_modifications.h
@@ -187,7 +187,7 @@ random_out_relocations(int n_tests)
 }
 
 void
-random_exchanges(int n_tests)
+random_inter_route_exchanges(int n_tests)
 {
 	for (int i = 0; i < n_tests; i++) {
 		generate_random_problem(MAX_N_CUSTOMERS);
@@ -207,10 +207,35 @@ random_exchanges(int n_tests)
 			int w_idx = randint(v_route_len, p.n_customers - 1);
 			struct customer *v = cs[v_idx];
 			w = cs[w_idx];
-			RANDOM_MODIFICATIONS_BEFORE_EXCHANGE;
+			RANDOM_MODIFICATIONS_BEFORE_INTER_ROUTE_EXCHANGE;
 			modify(EXCHANGE, v, w);
 			SWAP(cs[v_idx], cs[w_idx]);
-			RANDOM_MODIFICATIONS_AFTER_EXCHANGE;
+			RANDOM_MODIFICATIONS_AFTER_INTER_ROUTE_EXCHANGE;
+		}
+	}
+}
+
+void
+random_intra_route_exchanges(int n_tests)
+{
+	for (int i = 0; i < n_tests; i++) {
+		generate_random_problem(MAX_N_CUSTOMERS);
+		struct route *route = route_new();
+		struct customer *w;
+		int j = 0;
+		rlist_foreach_entry(w, &p.customers, in_route)
+			cs[j++] = w;
+		route_init(route, &cs[0], p.n_customers);
+
+		for (j = 0; j < p.n_customers; j++) {
+			int v_idx = randint(0, p.n_customers - 1);
+			int w_idx = randint(0, p.n_customers - 1);
+			struct customer *v = cs[v_idx];
+			w = cs[w_idx];
+			RANDOM_MODIFICATIONS_BEFORE_INTRA_ROUTE_EXCHANGE;
+			modify(EXCHANGE, v, w);
+			SWAP(cs[v_idx], cs[w_idx]);
+			RANDOM_MODIFICATIONS_AFTER_INTRA_ROUTE_EXCHANGE;
 		}
 	}
 }

--- a/test/unit/tw_penalty.c
+++ b/test/unit/tw_penalty.c
@@ -19,6 +19,7 @@ static const struct penalty_vtab tw_penalty_vtab = {
 	/* .penalty_two_opt_penalty_delta = */ tw_penalty_two_opt_penalty_delta,
 	/* .penalty_out_relocate_penalty_delta = */tw_penalty_out_relocate_penalty_delta,
 	/* .penalty_exchange_penalty_delta = */tw_penalty_exchange_penalty_delta,
+	/* .tw_penalty_exchange_penalty_delta_lower_bound = */tw_penalty_exchange_penalty_delta_lower_bound,
 };
 
 int
@@ -31,6 +32,7 @@ main(void)
 	random_replacements(100);
 	random_two_opts(100);
 	random_out_relocations(100);
-	random_exchanges(100);
+	random_inter_route_exchanges(100);
+	random_intra_route_exchanges(100);
 	return 0;
 }


### PR DESCRIPTION
Added `tw_penalty_exchange_penalty_delta_lower_bound` method to estimate the lower bound in the case of intra-route exchanges.