### PR TITLE
Add --seed for reproducible runs and standardize CLI value flags

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -74,4 +74,4 @@ jobs:
         ASAN: ON
         ASAN_OPTIONS: debug=true:heap_profile=0:detect_invalid_pointer_pairs=3:symbolize=1:detect_leaks=1:dump_instruction_bytes=1:print_suppressions=0
       run: |
-        ./debug-build-asan/routes GehringHomberger1000/C1_10_1.TXT C1_10_1.sol --lower_bound 100 --log_level=normal
+        ./debug-build-asan/routes GehringHomberger1000/C1_10_1.TXT C1_10_1.sol --lower_bound 100 --log_level normal

--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,7 @@ cmake-build-debug
 cmake-build-relwithdebinfo
 debug-build
 release-build
+build
 .idea
 GehringHomberger1000
 GehringHomberger200

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2,6 +2,9 @@ cmake_minimum_required(VERSION 3.5)
 
 project(routes C CXX ASM)
 
+# Required for pthread_setname_np, pthread_getattr_np on glibc/Linux
+add_definitions(-D_GNU_SOURCE)
+
 set(CMAKE_MODULE_PATH "${CMAKE_CURRENT_SOURCE_DIR}/cmake" ${CMAKE_MODULE_PATH})
 set(CMAKE_INCLUDE_PATH "${CMAKE_CURRENT_SOURCE_DIR}/cmake" ${CMAKE_INCLUDE_PATH})
 

--- a/README.md
+++ b/README.md
@@ -72,12 +72,13 @@ file1 - problem statement, file2 - where to output the solution
 
 Options:
   --beta_correction       - Enables beta-correction mechanism.
-  --log_level=<option>    - Log level: none, normal, verbose.
-  --n_near=<value>        - Sets the preferred n_near.
-  --k_max=<value>         - Sets the preferred k_max.
-  --t_max=<value>         - Sets the preferred t_max (in secs).
-  --i_rand=<value>        - Sets the preferred i_rand.
-  --lower_bound=<value>   - Sets the preferred lower_bound
+  --log_level <option>    - Log level: none, normal, verbose.
+  --n_near <value>        - Sets the preferred n_near.
+  --k_max <value>         - Sets the preferred k_max.
+  --t_max <value>         - Sets the preferred t_max (in secs).
+  --i_rand <value>        - Sets the preferred i_rand.
+  --lower_bound <value>   - Sets the preferred lower_bound.
+  --seed <value>          - Sets the pseudo-random seed.
 $ ./build/routes GehringHomberger1000/C1_10_1.TXT C1_10_1.sol --lower_bound 100 --t_max 120
 ```
 After completion, the current directory will contain a file with the solution, the name of which you specified when starting. In this example it is "C1_10_1.sol".

--- a/benchmark.py
+++ b/benchmark.py
@@ -97,7 +97,7 @@ def run_test(instance: str, problem_dir: Path, build_dir: Path,
         str(problem_file),
         str(solution_file),
         "--lower_bound", str(lower_bound),
-        "--log_level=normal",
+        "--log_level", "normal",
         "--t_max", str(time_limit_sec),
         "--beta_correction"
     ]

--- a/src/cli.c
+++ b/src/cli.c
@@ -4,6 +4,8 @@
 #include "stdio.h"
 #include "stdlib.h"
 #include "string.h"
+#include <errno.h>
+#include <limits.h>
 
 #include "core/diag.h"
 
@@ -27,12 +29,13 @@ usage(void)
 	printf("\n");
 	printf("Options:\n");
 	printf("  --beta_correction       - Enables beta-correction mechanism.\n");
-	printf("  --log_level=<option>    - Log level: none, normal, verbose.\n");
-	printf("  --n_near=<value>        - Sets the preferred n_near.\n");
-	printf("  --k_max=<value>         - Sets the preferred k_max.\n");
-	printf("  --t_max=<value>         - Sets the preferred t_max (in secs).\n");
-	printf("  --i_rand=<value>        - Sets the preferred i_rand.\n");
-	printf("  --lower_bound=<value>   - Sets the preferred lower_bound.\n");
+	printf("  --log_level <option>    - Log level: none, normal, verbose.\n");
+	printf("  --n_near <value>        - Sets the preferred n_near.\n");
+	printf("  --k_max <value>         - Sets the preferred k_max.\n");
+	printf("  --t_max <value>         - Sets the preferred t_max (in secs).\n");
+	printf("  --i_rand <value>        - Sets the preferred i_rand.\n");
+	printf("  --lower_bound <value>   - Sets the preferred lower_bound.\n");
+	printf("  --seed <value>          - Sets the pseudo-random seed.\n");
 }
 
 bool
@@ -71,21 +74,6 @@ match_longopt(const char *name)
 	return str_eq(&current_arg[2], name);
 }
 
-static inline bool
-match_shortopt(const char *name)
-{
-	return str_eq(&current_arg[1], name);
-}
-
-static inline const char *
-match_argopt(const char *name)
-{
-	size_t len = strlen(name);
-	if (memcmp(&current_arg[2], name, len) != 0) return false;
-	if (current_arg[2 + len] != '=') return false;
-	return &current_arg[2 + len + 1];
-}
-
 static int
 parse_multi_option(const char *start, unsigned count, const char **elements)
 {
@@ -95,78 +83,80 @@ parse_multi_option(const char *start, unsigned count, const char **elements)
 	return select;
 }
 
+static int
+parse_next_int_value(const char *name)
+{
+	if (at_end())
+		panic("error: --%s needs a valid integer.", name);
+
+	const char *value_string = next_arg();
+	char *p_end;
+	errno = 0;
+	long parsed = strtol(value_string, &p_end, 10);
+	if (p_end == value_string || errno != 0 ||
+	    p_end != value_string + strlen(value_string) ||
+	    parsed < INT_MIN || parsed > INT_MAX) {
+		panic("error: --%s needs a valid integer.", name);
+	}
+	return (int)parsed;
+}
+
+static uint64_t
+parse_next_uint64_value(const char *name)
+{
+	if (at_end())
+		panic("error: --%s needs a valid integer.", name);
+
+	const char *value_string = next_arg();
+	char *p_end;
+	errno = 0;
+	unsigned long long parsed = strtoull(value_string, &p_end, 10);
+	if (p_end == value_string || errno != 0 ||
+	    p_end != value_string + strlen(value_string)) {
+		panic("error: --%s needs a valid integer.", name);
+	}
+	return (uint64_t)parsed;
+}
+
 static void
 parse_option(void)
 {
-	const char *argopt;
 	switch (current_arg[1]) {
-		//case '?':
-		//	if (match_shortopt("?")) {
-		//		usage();
-		//		exit(0);
-		//	}
-		//	break;
 		case '-':
 			if (match_longopt("beta_correction")) {
 				options.beta_correction = true;
 				return;
 			}
-			if ((argopt = match_argopt("log_level"))) {
-				options.log_level = (log_level) parse_multi_option(argopt, 3, log_levels);
-				return;
-			}
-			if (match_longopt("n_near"))
-			{
+			if (match_longopt("log_level")) {
 				if (at_end())
-					panic("error: --n_near needs a valid integer.");
-				const char *n_near_string = next_arg();
-				char *p_end;
-				options.n_near = (int)strtol(n_near_string, &p_end, 10);
-				if (p_end != n_near_string + strlen(n_near_string))
-					panic("error: --n_near needs a valid integer.");
+					panic("error: --log_level needs a valid option.");
+				options.log_level =
+					(log_level) parse_multi_option(next_arg(), 3, log_levels);
 				return;
 			}
-			if (match_longopt("k_max"))
-			{
-				if (at_end())
-					panic("error: --k_max needs a valid integer.");
-				const char *k_max_string = next_arg();
-				char *p_end;
-				options.k_max = (int)strtol(k_max_string, &p_end, 10);
-				if (p_end != k_max_string + strlen(k_max_string))
-					panic("error: --k_max needs a valid integer.");
+			if (match_longopt("n_near")) {
+				options.n_near = parse_next_int_value("n_near");
 				return;
 			}
-			if (match_longopt("t_max"))
-			{
-				if (at_end()) panic("error: --t_max needs a valid integer.");
-				const char *t_max_string = next_arg();
-				char *p_end;
-				options.t_max = (int)strtol(t_max_string, &p_end, 10);
-				if (p_end != t_max_string + strlen(t_max_string))
-					panic("error: --t_max needs a valid integer.");
+			if (match_longopt("k_max")) {
+				options.k_max = parse_next_int_value("k_max");
 				return;
 			}
-			if (match_longopt("i_rand"))
-			{
-				if (at_end())
-					panic("error: --i_rand needs a valid integer.");
-				const char *i_rand_string = next_arg();
-				char *p_end;
-				options.i_rand = (int)strtol(i_rand_string, &p_end, 10);
-				if (p_end != i_rand_string + strlen(i_rand_string))
-					panic("error: --k_max needs a valid integer.");
+			if (match_longopt("t_max")) {
+				options.t_max = (clock_t)parse_next_int_value("t_max");
 				return;
 			}
-			if (match_longopt("lower_bound"))
-			{
-				if (at_end())
-					panic("error: --lower_bound needs a valid integer.");
-				const char *lower_bound_string = next_arg();
-				char *p_end;
-				options.lower_bound = (int)strtol(lower_bound_string, &p_end, 10);
-				if (p_end != lower_bound_string + strlen(lower_bound_string))
-					panic("error: --lower_bound needs a valid integer.");
+			if (match_longopt("i_rand")) {
+				options.i_rand = parse_next_int_value("i_rand");
+				return;
+			}
+			if (match_longopt("lower_bound")) {
+				options.lower_bound = parse_next_int_value("lower_bound");
+				return;
+			}
+			if (match_longopt("seed")) {
+				options.seed = parse_next_uint64_value("seed");
+				options.has_seed = true;
 				return;
 			}
 		default:
@@ -196,6 +186,8 @@ parse_arguments(int argc, const char *argv[])
 	options.t_max = (clock_t)365 * 86400 * 100;
 	options.i_rand = 1000;
 	options.lower_bound = 0;
+	options.has_seed = false;
+	options.seed = 0;
 
 	for (arg_index = 3; arg_index < arg_count; arg_index++)
 	{

--- a/src/cli.h
+++ b/src/cli.h
@@ -2,6 +2,7 @@
 #define EAMA_ROUTES_MINIMIZATION_HEURISTIC_CLI_ARGS_H
 
 #include <stdbool.h>
+#include <stdint.h>
 #include <time.h>
 
 typedef enum
@@ -22,6 +23,8 @@ struct cli_options {
     clock_t t_max;
     int i_rand;
     int lower_bound;
+    bool has_seed;
+    uint64_t seed;
 };
 
 extern struct cli_options options;

--- a/src/lib/core/random.c
+++ b/src/lib/core/random.c
@@ -39,9 +39,19 @@
 //#include "say.h"
 #include "tt_static.h"
 
-static int rfd;
+static int rfd = -1;
 
 static uint64_t state[4];
+
+static inline uint64_t
+splitmix64_next(uint64_t *x)
+{
+	*x += 0x9E3779B97F4A7C15ULL;
+	uint64_t z = *x;
+	z = (z ^ (z >> 30)) * 0xBF58476D1CE4E5B9ULL;
+	z = (z ^ (z >> 27)) * 0x94D049BB133111EBULL;
+	return z ^ (z >> 31);
+}
 
 void
 random_init(void)
@@ -70,8 +80,19 @@ random_init(void)
 srand:
 	srandom(seed);
 	srand(seed);
-
 	random_bytes((char *)state, sizeof(state));
+}
+
+void
+pseudo_random_seed(uint64_t seed)
+{
+	uint64_t mix = seed;
+	/*
+	 * The solver uses xoshiro256++ for pseudo-randomness. Seed only that
+	 * generator so deterministic runs do not alter the entropy-backed API.
+	 */
+	for (int i = 0; i < 4; i++)
+		state[i] = splitmix64_next(&mix);
 }
 
 void
@@ -80,6 +101,7 @@ random_free(void)
 	if (rfd == -1)
 		return;
 	close(rfd);
+	rfd = -1;
 }
 
 void
@@ -102,7 +124,6 @@ random_bytes(char *buf, size_t size)
 		attempt = 0;
 	}
 rand:
-	/* fill remaining bytes with PRNG */
 	while (generated < size)
 		buf[generated++] = rand();
 }

--- a/src/lib/core/random.h
+++ b/src/lib/core/random.h
@@ -40,9 +40,24 @@ extern "C" {
 void
 random_init(void);
 
+/**
+ * Seed the xoshiro256++ pseudo-random generator used by the solver.
+ *
+ * This does not affect random_bytes(), real_random(), or any entropy source
+ * configured by random_init().
+ */
+void
+pseudo_random_seed(uint64_t seed);
+
 void
 random_free(void);
 
+/**
+ * Fill `buf` with random bytes.
+ *
+ * Prefer the OS entropy source configured by random_init(). If entropy reads
+ * are unavailable or partial, remaining bytes are generated via libc rand().
+ */
 void
 random_bytes(char *buf, size_t size);
 
@@ -61,9 +76,7 @@ uint64_t
 xoshiro_random(void);
 
 /**
- * Sets the `seed` for a new sequence of pseudo-random integers to be returned
- * by xoshiro_random(). These sequences are repeatable by calling xoshiro_srand
- * with the same seed value.
+ * Sets the xoshiro256++ internal state directly.
  */
 void
 xoshiro_srand(uint64_t *seed);

--- a/src/main.c
+++ b/src/main.c
@@ -5,6 +5,7 @@
 
 #include "core/fiber.h"
 #include "core/memory.h"
+#include "core/random.h"
 
 int
 main(int argc, const char *argv[])
@@ -14,6 +15,8 @@ main(int argc, const char *argv[])
 	memory_init();
 	fiber_init(fiber_c_invoke);
 	random_init();
+	if (options.has_seed)
+		pseudo_random_seed(options.seed);
 
 	problem_decode(options.problem_file);
 

--- a/test/unit/CMakeLists.txt
+++ b/test/unit/CMakeLists.txt
@@ -64,3 +64,8 @@ create_unit_test(PREFIX ejection
                  SOURCES ejection.c ${common_sources}
                  LIBRARIES core unit
 )
+
+create_unit_test(PREFIX random
+                 SOURCES random.c
+                 LIBRARIES core unit
+)

--- a/test/unit/random.c
+++ b/test/unit/random.c
@@ -1,0 +1,53 @@
+#include "unit.h"
+
+#include <stdint.h>
+#include <string.h>
+
+#include "core/random.h"
+
+int
+main(void)
+{
+	plan(3);
+
+	random_init();
+
+	uint64_t seq1[4];
+	uint64_t seq2[4];
+	uint64_t seq3[4];
+	int64_t bounded1[8];
+	int64_t bounded2[8];
+
+	pseudo_random_seed(0x0123456789ABCDEFULL);
+	for (int i = 0; i < 4; i++)
+		seq1[i] = xoshiro_random();
+
+	pseudo_random_seed(0x0123456789ABCDEFULL);
+	for (int i = 0; i < 4; i++)
+		seq2[i] = xoshiro_random();
+
+	ok(memcmp(seq1, seq2, sizeof(seq1)) == 0,
+	   "xoshiro sequence is repeatable for the same 64-bit seed");
+
+	pseudo_random_seed(0x0123456789ABCDEEULL);
+	for (int i = 0; i < 4; i++)
+		seq3[i] = xoshiro_random();
+
+	ok(memcmp(seq1, seq3, sizeof(seq1)) != 0,
+	   "xoshiro sequence changes with different 64-bit seed");
+
+	pseudo_random_seed(0xDEADBEEFCAFEBABEULL);
+	for (int i = 0; i < 8; i++)
+		bounded1[i] = pseudo_random_in_range(-7, 23);
+
+	pseudo_random_seed(0xDEADBEEFCAFEBABEULL);
+	for (int i = 0; i < 8; i++)
+		bounded2[i] = pseudo_random_in_range(-7, 23);
+
+	ok(memcmp(bounded1, bounded2, sizeof(bounded1)) == 0,
+	   "bounded pseudo-random sequence is repeatable for the same 64-bit seed");
+
+	random_free();
+
+	return check_plan();
+}


### PR DESCRIPTION
Hello. I'm @0nyr, a PhD student currently working on VRPTW with hierarchical objective. I'm grateful for your amazing project and propose some modifs to improve some of its aspects related to CLI and RNG seeding. 

## Summary

This PR does related cleanups around reproducibility and CLI consistency:

1. It adds a new `--seed` CLI flag so seeded solver runs can be requested explicitly from the command line, which is useful for consistent benchmarking.
2. It makes the seed contract explicit by seeding only the solver pseudo-RNG.
3. It standardizes value-taking CLI flags on the `--flag <value>` form and aligns the help text and helper scripts with that convention.

The original motivation was to support repeatable benchmarking runs from the CLI, while also avoiding ambiguity about what parts of the random API are actually affected by `--seed`.

## What changed

### 1. Clarify and narrow the seed contract

The old `random_seed()` name suggested a process-wide or API-wide seeding contract, but that was not what the solver actually needed.

This PR:

- adds a new `--seed <value>` CLI flag
- renames `random_seed()` to `pseudo_random_seed()`
- wires `--seed` into the solver entrypoint
- documents that this function seeds the xoshiro-based pseudo-RNG used by the solver
- restores `random_bytes()` / `real_random()` to their original entropy-backed semantics

The key user-facing addition here is that benchmark or experiment scripts can now request reproducible solver runs directly through the CLI instead of relying on implicit process state or local code changes.

This makes the contract explicit:

- `pseudo_random_seed()` affects the solver pseudo-random sequence
- it does **not** claim to make `random_bytes()`, `real_random()`, or OS-backed entropy deterministic

That separation is intentional. It keeps the solver reproducibility story clear without overloading the meaning of the generic random API.

### 2. Clean up CLI conventions

Before this change, the CLI was inconsistent:

- the help text advertised `--flag=<value>`
- most numeric options were actually parsed as `--flag <value>`
- `log_level` had its own special parsing path
- the newly added `--seed` followed the numeric-options implementation but not the help text

This PR standardizes value-taking options on:

```text
--flag <value>
```

This now applies consistently to:

- `--log_level`
- `--n_near`
- `--k_max`
- `--t_max`
- `--i_rand`
- `--lower_bound`
- `--seed`

The help text and the local benchmark helper script were updated to match.

## Why these choices

### Naming

`pseudo_random_seed()` is more honest than `random_seed()`.

The solver relies on the xoshiro pseudo-RNG path, so the name should reflect that directly. It also matches the existing naming around `pseudo_random_in_range()`.

### Randomness boundaries

The important distinction here is:

- entropy-backed randomness is one thing
- deterministic solver pseudo-randomness is another

In simpler terms: for benchmarking, what we care about is that the solver makes the same random choices when given the same instance and the same seed.

We do **not** need `--seed` to magically make every source of randomness in the whole process deterministic. That would be a broader promise:

- OS entropy reads would have to be redefined or bypassed
- generic helper functions would need to follow the same rule
- the meaning of `--seed` would become much larger and less obvious

Trying to make one API name cover both leads to confusion. This PR keeps those responsibilities separate instead of implying that one seed makes the whole random subsystem deterministic.

### CLI style

I chose `--flag <value>` rather than `--flag=<value>` for one reason: that was already the de facto convention in the implementation for the numeric options.

So this PR does not invent a new CLI style. It removes a mismatch between documentation and behavior, and it makes `log_level` and `seed` follow the same convention as the rest.

This also makes the new `--seed` flag consistent with the rest of the interface instead of introducing a special-case syntax for benchmarking.

From a user perspective, the `--flag <value>` style is also more common in CLI tools, so it should be more familiar.

## Behavior after this PR

A typical invocation now looks like:

```bash
./build/routes INSTANCE.TXT solution.sol --lower_bound 100 --t_max 60 --seed 42 --log_level none
```

The important point is that reproducible seeded runs are now available as a normal CLI feature. Seeded runs are deterministic with respect to the solver pseudo-RNG sequence used by the route minimization code.

## Caveats / compatibility notes

- `--seed=<value>` is not supported by this PR. The parser is intentionally standardized on the split-token style.
- Existing wrappers or scripts using `--log_level=...` or `--seed=...` will need a small update.
- This does **not** promise deterministic behavior for every function in `core/random.*`. It is specifically about making the solver's own randomized decisions reproducible.
- Deterministic solver behavior assumes the solver continues to use the pseudo-random path rather than the entropy-backed path for its randomized decisions.
- The benchmarking value of `--seed` is consistency and repeatability across runs with the same binary and inputs. It should not be read as a promise of identical behavior across arbitrary future algorithmic changes.

## Potential follow-ups

- If backward compatibility is important, the CLI parser could be extended to accept both `--flag value` and `--flag=value`. I did not do that here because the simpler parser and single convention seemed preferable.
- If someone ever wants "everything in the process to become deterministic from one seed", that should be a separate feature with a separate contract. That would be bigger than solver reproducibility, and it would deserve a more explicit design than folding it into `--seed` implicitly.

## Validation

I validated this change with:

- the focused `random.test` unit test
- rebuild of the `routes` target
- repeated seeded runs of `routes` on the same instance, confirming identical stdout and identical solution output for the same seed

The updated unit test now checks the intended contract directly:

- same seed => same xoshiro sequence
- different seed => different xoshiro sequence
- same seed => same bounded pseudo-random sequence

## Review notes

The main design point to review is the intended scope of `--seed`.

This PR deliberately keeps that scope narrow:

- a reproducible solver-side CLI seed for benchmarking
- reproducible solver pseudo-randomness
- no stronger guarantee than that

If that is the intended behavior, then the rename and API cleanup make the code much less ambiguous.
