### PR TITLE
Add hot-start support and structured incumbent logging for experiment integration

### DIFF
--- a/src/cli.c
+++ b/src/cli.c
@@ -33,9 +33,12 @@ usage(void)
 	printf("  --n_near <value>        - Sets the preferred n_near.\n");
 	printf("  --k_max <value>         - Sets the preferred k_max.\n");
 	printf("  --t_max <value>         - Sets the preferred t_max (in secs).\n");
+	printf("  --t_max_ms <value>      - Sets the budget in milliseconds (overrides --t_max).\n");
 	printf("  --i_rand <value>        - Sets the preferred i_rand.\n");
 	printf("  --lower_bound <value>   - Sets the preferred lower_bound.\n");
 	printf("  --seed <value>          - Sets the pseudo-random seed.\n");
+	printf("  --initial_solution <f>  - Import initial solution from file.\n");
+	printf("  --log_incumbent_solutions - Emit full incumbent routes as JSON lines.\n");
 }
 
 bool
@@ -142,8 +145,23 @@ parse_option(void)
 				options.k_max = parse_next_int_value("k_max");
 				return;
 			}
+			if (match_longopt("t_max_ms")) {
+				options.t_max_ms = (int64_t)parse_next_int_value("t_max_ms");
+				options.has_t_max_ms = true;
+				return;
+			}
 			if (match_longopt("t_max")) {
 				options.t_max = (clock_t)parse_next_int_value("t_max");
+				return;
+			}
+			if (match_longopt("initial_solution")) {
+				if (at_end())
+					panic("error: --initial_solution needs a file path.");
+				options.initial_solution_file = next_arg();
+				return;
+			}
+			if (match_longopt("log_incumbent_solutions")) {
+				options.log_incumbent_solutions = true;
 				return;
 			}
 			if (match_longopt("i_rand")) {
@@ -179,11 +197,15 @@ parse_arguments(int argc, const char *argv[])
 
 	options.problem_file = args[1];
 	options.solution_file = args[2];
+	options.initial_solution_file = NULL;
+	options.log_incumbent_solutions = false;
 	options.beta_correction = false;
 	options.log_level = LOGLEVEL_VERBOSE;
 	options.n_near = 100;
 	options.k_max = 5;
 	options.t_max = (clock_t)365 * 86400 * 100;
+	options.t_max_ms = -1;
+	options.has_t_max_ms = false;
 	options.i_rand = 1000;
 	options.lower_bound = 0;
 	options.has_seed = false;

--- a/src/cli.h
+++ b/src/cli.h
@@ -16,11 +16,15 @@ typedef enum
 struct cli_options {
     const char *problem_file;
     const char *solution_file;
+    const char *initial_solution_file; /* NULL when not provided */
+    bool log_incumbent_solutions;
 	bool beta_correction;
     log_level log_level;
     int n_near;
     int k_max;
     clock_t t_max;
+    int64_t t_max_ms;   /* millisecond budget; -1 when not provided */
+    bool has_t_max_ms;
     int i_rand;
     int lower_bound;
     bool has_seed;

--- a/src/eama_solver.c
+++ b/src/eama_solver.c
@@ -22,6 +22,15 @@ const char	*RESET 	= "\033[0m",
 	fflush(stdout);												\
 } while (0)
 
+static void
+log_incumbent(struct solution *s, long elapsed_ms)
+{
+	printf("incumbent_ms: %ld n_routes: %d\n", elapsed_ms, s->n_routes);
+	fflush(stdout);
+	if (options.log_incumbent_solutions)
+		solution_print_incumbent_json(s, elapsed_ms);
+}
+
 int
 insert_feasible(struct solution *s)
 {
@@ -376,12 +385,28 @@ eama_solver_solve(void)
 	eama_solver.alpha = eama_solver.beta = 1.;
 	memset(&eama_solver.p[0], 0, sizeof(eama_solver.p));
 
-	clock_t deadline = clock() + CLOCKS_PER_SEC * options.t_max;
+	/* Compute deadline with sub-second precision when --t_max_ms is used */
+	clock_t start_clock = clock();
+	clock_t deadline;
+	if (options.has_t_max_ms)
+		deadline = start_clock +
+			   (clock_t)((double)options.t_max_ms / 1000.0 * CLOCKS_PER_SEC);
+	else
+		deadline = start_clock + CLOCKS_PER_SEC * options.t_max;
+
 	int lower_bound = MAX(problem_routes_straight_lower_bound(),
 			      options.lower_bound);
 
-	struct solution *s = solution_default();
+	/* Build initial solution: imported or default (trivial) */
+	struct solution *s;
+	if (options.initial_solution_file != NULL)
+		s = solution_decode(options.initial_solution_file);
+	else
+		s = solution_default();
 	solution_check_missed_customers(s);
+
+	/* Log initial incumbent at t=0 */
+	log_incumbent(s, 0);
 
 	while (s->n_routes > lower_bound) {
 		if (options.log_level >= LOGLEVEL_NORMAL)
@@ -392,6 +417,12 @@ eama_solver_solve(void)
 		assert(s->w == NULL);
 		solution_check_missed_customers(s);
 		assert(rlist_empty(&s->ejection_pool));
+
+		/* Log incumbent after successful route deletion */
+		clock_t now = clock();
+		long elapsed_ms = (long)((double)(now - start_clock) /
+					 CLOCKS_PER_SEC * 1000.0);
+		log_incumbent(s, elapsed_ms);
 	}
 	assert(s->w == NULL);
 	assert(rlist_empty(&s->ejection_pool));

--- a/src/solution.cc
+++ b/src/solution.cc
@@ -4,11 +4,16 @@
 #include "modification.h"
 
 #include <cassert>
+#include <cstdio>
+#include <cstring>
 
 #include "core/fiber.h"
 #include "core/random.h"
 #include "core/exception.h"
 
+#include <fstream>
+#include <sstream>
+#include <string>
 #include <vector>
 #include <algorithm>
 
@@ -367,6 +372,54 @@ solution_print(solution *s)
 	fflush(stdout);
 }
 
+double
+solution_routing_cost(solution *s)
+{
+	double total = 0.;
+	for (int i = 0; i < s->n_routes; i++) {
+		route *r = s->routes[i];
+		customer *prev = depot_head(r);
+		for (customer *curr = route_next(prev);
+		     curr != depot_tail(r);
+		     curr = route_next(curr)) {
+			total += dist(prev, curr);
+			prev = curr;
+		}
+		total += dist(prev, depot_tail(r));
+	}
+	return total;
+}
+
+void
+solution_print_incumbent_json(solution *s, long elapsed_ms)
+{
+	printf(
+		"incumbent_solution_json: "
+		"{\"elapsed_ms\":%ld,\"num_routes\":%d,\"native_cost\":%.12f,\"routes\":[",
+		elapsed_ms,
+		s->n_routes,
+		solution_routing_cost(s)
+	);
+	for (int i = 0; i < s->n_routes; i++) {
+		if (i > 0)
+			printf(",");
+		printf("[");
+		bool first_customer = true;
+		customer *c;
+		route_foreach(c, s->routes[i]) {
+			if (c->id == 0)
+				continue;
+			if (!first_customer)
+				printf(",");
+			printf("%d", c->id);
+			first_customer = false;
+		}
+		printf("]");
+	}
+	printf("]}\n");
+	fflush(stdout);
+}
+
 solution *
 solution_default(void)
 {
@@ -391,6 +444,103 @@ solution_default(void)
 		++i;
 	}
 	assert(i == p.n_customers);
+	return s;
+}
+
+solution *
+solution_decode(const char *file)
+{
+	std::string file_string{file};
+	std::ifstream f{file_string};
+	if (!f.is_open())
+		panic("solution_decode: cannot open file '%s'", file);
+
+	/* Parse routes: one route per line, space-separated 1-indexed customer IDs */
+	std::vector<std::vector<int>> parsed_routes;
+	std::string line;
+	while (std::getline(f, line)) {
+		/* skip blank lines and comments */
+		size_t first = line.find_first_not_of(" \t\r\n");
+		if (first == std::string::npos)
+			continue;
+		if (line[first] == '#')
+			continue;
+
+		std::istringstream iss(line);
+		std::vector<int> route_ids;
+		int id;
+		while (iss >> id)
+			route_ids.push_back(id);
+		if (route_ids.empty())
+			continue;
+		parsed_routes.push_back(std::move(route_ids));
+	}
+
+	if (parsed_routes.empty())
+		panic("solution_decode: file '%s' contains no routes", file);
+
+	/* Validate: all customers present exactly once, no depot, in range */
+	bool used[MAX_N_CUSTOMERS + 1];
+	memset(used, 0, sizeof(used));
+	int total_customers = 0;
+
+	for (int ri = 0; ri < (int)parsed_routes.size(); ri++) {
+		if (parsed_routes[ri].empty())
+			panic("solution_decode: route %d is empty", ri + 1);
+		for (int cid : parsed_routes[ri]) {
+			if (cid == 0)
+				panic("solution_decode: depot (0) must not appear in initial solution");
+			if (cid < 1 || cid > p.n_customers)
+				panic("solution_decode: customer ID %d out of range [1, %d]",
+				      cid, p.n_customers);
+			if (used[cid])
+				panic("solution_decode: customer %d appears more than once", cid);
+			used[cid] = true;
+			total_customers++;
+		}
+	}
+
+	if (total_customers != p.n_customers) {
+		int missing = 0;
+		for (int i = 1; i <= p.n_customers; i++)
+			if (!used[i]) missing++;
+		panic("solution_decode: %d customer(s) missing from initial solution", missing);
+	}
+
+	/* Build solution following the same pattern as solution_default() */
+	auto *s = (solution *)xmalloc(sizeof(solution) +
+		sizeof(struct route *) * p.n_customers);
+
+	s->w = nullptr;
+
+	RLIST_HEAD(problem_customers);
+	problem_customers_dup(&problem_customers);
+	s->meta = solution_meta_new(&problem_customers);
+	assert(rlist_empty(&problem_customers));
+
+	rlist_create(&s->ejection_pool);
+	s->n_routes = (int)parsed_routes.size();
+
+	/* Temp array for route_init */
+	struct customer *arr[MAX_N_CUSTOMERS];
+
+	for (int i = 0; i < s->n_routes; i++) {
+		const auto &rids = parsed_routes[i];
+		int n = (int)rids.size();
+		for (int j = 0; j < n; j++)
+			arr[j] = s->meta->idx[rids[j]];
+
+		route *r = route_new();
+		route_init(r, arr, n);
+		s->routes[i] = r;
+	}
+
+	/* Post-build validation */
+	solution_check_missed_customers(s);
+	if (!solution_feasible(s))
+		panic("solution_decode: imported solution is infeasible "
+		      "(time windows or capacity violated)");
+
 	return s;
 }
 

--- a/src/solution.h
+++ b/src/solution.h
@@ -31,6 +31,14 @@ solution_modification_neighbourhood_f(va_list ap);
 struct solution *
 solution_default(void);
 
+/**
+ * Build a solution from an external file.
+ * File format: one route per line, space-separated 1-indexed customer IDs.
+ * Panics on validation failure or infeasible solution.
+ */
+struct solution *
+solution_decode(const char *file);
+
 /* TODO: deprecate */
 struct solution *
 solution_dup(struct solution *s);
@@ -52,6 +60,12 @@ solution_feasible(struct solution *s);
 
 void
 solution_print(struct solution *s);
+
+double
+solution_routing_cost(struct solution *s);
+
+void
+solution_print_incumbent_json(struct solution *s, long elapsed_ms);
 
 void ALWAYS_INLINE
 solution_check_routes(struct solution *s)


### PR DESCRIPTION
This PR adds some missing features to support applied algorithmic experiments. 

## Practical reason this matters for paper6

These additions are what make NBRMH usable as a controlled upper-bound component in paper6:

- hot-starting allows to seed NBRMH from an external heuristic solution
- structured incumbent logging allows to reconstruct anytime behavior cleanly
- millisecond budgets make short controlled runs reproducible in the experimental pipeline

Without these hooks, NBRMH remains a strong solver, but it is much harder to integrate cleanly into a reproducible experimental workflow.

## Summary of the contribution

1. Hot-start support from an external solution file

- adds `--initial_solution <file>`
- imports a route set from disk
- validates that every customer appears exactly once and that the imported solution is feasible
- starts NBRMH from that incumbent instead of from the trivial default solution

2. Structured incumbent logging for experiment integration

- logs the initial incumbent at `t = 0`
- logs later incumbents after successful route deletions
- adds optional `--log_incumbent_solutions`
- emits machine-readable JSON lines containing:
  - `elapsed_ms`
  - `num_routes`
  - `native_cost`
  - full route lists

3. Millisecond-level time-budget control

- adds `--t_max_ms <value>`
- lets paper6 run NBRMH with sub-second budgets without losing precision through second-based rounding

> Note that I merged upstream @Astronomax latest changes with Codex 5.4. All changes have been reviewed and checked against my paper6 integration tests.
